### PR TITLE
Initial translation

### DIFF
--- a/pages/beta-builds.pt-br.md
+++ b/pages/beta-builds.pt-br.md
@@ -1,0 +1,21 @@
+# Beta Builds
+
+From time to time, beta builds are released before a new version is published. If you want to get in on this process, let me know on [Twitter](https://twitter.com/six7) by writing a DM.
+
+### Installing a development build
+
+If you received a beta build, here's a short guide explaining how to install it. First of all, it's important that you're using the Figma Desktop app. Development builds won't work on the browser version of Figma. [Download it here.](https://www.figma.com/downloads/)
+
+To get started, click on the menu icon in Figma and type `Manage` — you should find the entry `Manage plugins`. Click on it.
+
+![](/manage-plugins.jpg)
+
+Next, click on Create new plugin in the Development section.
+
+![](/create-new-plugin.jpg)
+
+Then click on `Choose a manifest.json file` and navigate to where you downloaded the ZIP File. Select the `manifest.json` file.
+
+![](/choose-manifest.jpg)
+
+That's it! You now got a development build of Figma Tokens. Start it by right clicking anywhere in a document and choose `Plugins > Figma Tokens (Dev)`

--- a/pages/beta-builds.pt-br.md
+++ b/pages/beta-builds.pt-br.md
@@ -1,21 +1,21 @@
-# Beta Builds
+# Compilações Beta
 
-From time to time, beta builds are released before a new version is published. If you want to get in on this process, let me know on [Twitter](https://twitter.com/six7) by writing a DM.
+De tempos em tempos, compilações beta são lançadas antes que uma nova versão seja publicada. Se você quiser entrar neste processo, deixe-me saber no [Twitter] (https://twitter.com/six7) escrevendo um DM.
 
-### Installing a development build
+### Instalando uma compilação de desenvolvimento
 
-If you received a beta build, here's a short guide explaining how to install it. First of all, it's important that you're using the Figma Desktop app. Development builds won't work on the browser version of Figma. [Download it here.](https://www.figma.com/downloads/)
+Se você recebeu uma versão beta, aqui está um pequeno guia que explica como instalá-la. Em primeiro lugar, é importante que você esteja usando o aplicativo Figma Desktop. As compilações de desenvolvimento não funcionarão na versão do navegador do Figma. [Baixe aqui.] (Https://www.figma.com/downloads/)
 
-To get started, click on the menu icon in Figma and type `Manage` — you should find the entry `Manage plugins`. Click on it.
+Para começar, clique no ícone do menu na Figma e digite `Manage` - você deve encontrar a entrada `Manage plugins`. Clique nele.
 
 ![](/manage-plugins.jpg)
 
-Next, click on Create new plugin in the Development section.
+Em seguida, clique em `Create new plugin` na seção `Development`.
 
 ![](/create-new-plugin.jpg)
 
-Then click on `Choose a manifest.json file` and navigate to where you downloaded the ZIP File. Select the `manifest.json` file.
+Em seguida, clique em `Choose a manifest.json file` e navegue até o local onde você baixou o arquivo ZIP. Selecione o arquivo `manifest.json`.
 
 ![](/choose-manifest.jpg)
 
-That's it! You now got a development build of Figma Tokens. Start it by right clicking anywhere in a document and choose `Plugins > Figma Tokens (Dev)`
+É isso! Agora você tem uma compilação de desenvolvimento do Figma Tokens. Comece clicando com o botão direito em qualquer lugar em um documento e escolha `Plugins > Figma Tokens (Dev)`

--- a/pages/getting-started.pt-br.md
+++ b/pages/getting-started.pt-br.md
@@ -9,7 +9,7 @@ Ao usar o plugin pela primeira vez você não terá token algum definido. Clique
 Agora você vai poder continuar dentre três maneiras:
 
 - Criar seus próprios tokens pela UI do plugin
-- Importar seus tokens já feitos em algum projeto
-- Criar sus tokens através de um editor JSON
+- Importar seus tokens já feitos em algum projeto (através do botão `Import Styles`)
+- Criar seus tokens através de um editor JSON
 
 ![](/import-styles.jpg)

--- a/pages/getting-started.pt-br.md
+++ b/pages/getting-started.pt-br.md
@@ -1,0 +1,15 @@
+# Iniciando o uso
+
+Instale o Figma Tokens pressionando o botão `Install` [nesta página](https://www.figma.com/community/plugin/843461159747178978/Figma-Tokens) (tanto na versão Desktop quando em seu navegador).
+
+Isso irá instalar o plugin para você.
+
+Ao usar o plugin pela primeira vez você não terá token algum definido. Clique em `Configure Tokens` para iniciar.
+
+Agora você vai poder continuar dentre três maneiras:
+
+- Criar seus próprios tokens pela UI do plugin
+- Importar seus tokens já feitos em algum projeto
+- Criar sus tokens através de um editor JSON
+
+![](/import-styles.jpg)

--- a/pages/index.pt-br.md
+++ b/pages/index.pt-br.md
@@ -2,7 +2,7 @@
 
 **Figma Tokens** é um [Plugin do Figma](https://jansix.at/resources/figma-tokens) que permite integrar o conceito de Design Tokens em seus projetos no Figma.
 
-Ele lhe permite criar tokens reutilizáveis que podem ser aplicados com grande abrangência de opções, desde o arredondamento de bordas até unidades semânticas de cores ou estilos tipográficos. Ele permite a alteração de tokens e que essas alterações sejam aplicadas em todo o documento ou em seus estilos.
+Ele lhe permite criar tokens reutilizáveis que podem ser aplicados com grande abrangência de opções, desde o arredondamento de bordas até unidades semânticas de cores ou estilos tipográficos. Você pode também controlar e alterar seus tokens de forma que isso seja se reflita em todo o documento ou em seus estilos.
 
 ![](/tokens-intro.jpg)
 

--- a/pages/index.pt-br.md
+++ b/pages/index.pt-br.md
@@ -1,0 +1,9 @@
+# Figma Tokens
+
+**Figma Tokens** é um [Plugin do Figma](https://jansix.at/resources/figma-tokens) que permite integrar o conceito de Design Tokens em seus projetos no Figma.
+
+Ele lhe permite criar tokens reutilizáveis que podem ser aplicados com grande abrangência de opções, desde o arredondamento de bordas até unidades semânticas de cores ou estilos tipográficos. Ele permite a alteração de tokens e que essas alterações sejam aplicadas em todo o documento ou em seus estilos.
+
+![](/tokens-intro.jpg)
+
+**Nota da tradução em Português Brasileiro:** decidimos manter as nomenclaturas com os nomes originais das propriedades de CSS e do Figma para os tokens, categorias e demais itens relacionados com desenvolvimnto. Porém, usamos a tradução em colunas de tabelas ou entre parenteses. O objetivo disso é abranger todos os profissionais, desde os que usam a ferramenta em português até os que preferem o idioma original (Inglês) - até mesmo os precisam das referências originais para código (**Exemplo:** não há CSS em português).

--- a/pages/styles.pt-br.md
+++ b/pages/styles.pt-br.md
@@ -1,0 +1,163 @@
+# Estilos (Styles)
+
+Em vez de criar manualmente todos os tokens, você pode deixar o plug-in fazer o trabalho por você.
+
+No documento onde seus estilos estão localizados, clique em `Import Styles` no canto superior direito do plugin.
+
+---
+
+import ReactPlayer from 'react-player'
+
+
+<ReactPlayer
+  muted
+  width="100%"
+  height="auto"
+  loop
+  playing
+  controls
+  url="/cxqos7Yhr4.mp4"
+/>
+
+O plugin irá converter automaticamente estilos de cores e tipografia em tokens para você. O que há de melhor nessa abordagem é que o plug-in tenta determinar suas unidades básicas e criar tokens para elas.
+
+Isso significa que seus 4 estilos referenciando `Inter` como uma família de fontes, com 2 pesos de fonte, `Regular` e `Bold` se tornarão um conjunto de tokens de base (options) de `font-inter`, `font-weight-bold`, vários tamanhos de fonte, altura de linha, espaçamento entre letras e/ou parágrafo em um conjunto de tokens de Tipografia (decisões de estilo compostas por essas unidades básicas).
+
+Este processo não é perfeito (ainda), mas com um pouco de ajuste manual você obterá um conjunto de tokens que é fácil de atualizar mais tarde.
+
+import Callout from 'nextra-theme-docs/callout'
+
+<Callout emoji="💡">
+  A importação de estilos que possuem um ponto (`.`) em seus nomes não funcionará no momento. Use `/` como um divisor.
+</Callout>
+
+## Tokens de Cores
+
+Importar estilos de cores para tokens é bastante simples. O que o plug-in fará é criar conjuntos de tokens de acordo com a nomenclatura de seus estilos de base, para que você obtenha tokens semelhantes a estes:
+
+```
+ "colors": {
+    "Black": "#212121",
+    "White": "#ffffff",
+    "Primary ": {
+      "100 T": "#e9f4ff",
+      "200 T": "#d2e9ff",
+      "300 T": "#8fc8ff",
+      "400 T": "#4ba6ff",
+      "500 (Base)": "#1e90ff",
+      "600 S": "#1565b3",
+      "700 S": "#0c3a66",
+      "800 S": "#061d33",
+      "900 S": "#030e19"
+    },
+    "Secondary ": {
+      "100 T": "#e7efff",
+      "200 T": "#cfdffe",
+      "300 T": "#a0bffd",
+      "400 T": "#709ffd",
+      "500 (Base)": "#115ffb",
+      "600 S": "#0a3997",
+      "700 S": "#072664",
+      "800 S": "#031332",
+      "900 S": "#020919"
+    },
+```
+
+
+## Tokens de Tipografia
+
+Os tokens de tipografia suportados por enquanto são:
+
+- Famílias de fontes
+- Pesos de fonte
+- Tamanhos de fonte
+- Alturas de linha
+- Espaçamento entre letras
+- Espaçamento de parágrafo
+
+O Token JSON resultante para esses estilos importados será semelhante a este:
+
+```
+"fontFamilies": {
+    "heading": "Monument Extended",
+    "body": "Circular Std"
+  },
+  "lineHeights": {
+    "body": "140%",
+    "auto": "AUTO",
+    "none": "100%",
+    "tight": "110%"
+  },
+  "fontWeights": {
+    "heading": {
+      "regular": "Regular",
+      "bold": "Bold"
+    },
+    "body": {
+      "regular": "Regular",
+      "bold": "Bold"
+    }
+  },
+  "fontSizes": {
+    "sm": "16",
+    "lg": "20",
+    "xl": "25",
+    "2xl": "31",
+  },
+  "letterSpacing": {
+    "normal": "0%",
+    "tight": "-1%",
+    "tighter": "-3%",
+    "wide": "5%"
+  },
+}
+```
+
+A importação de estilos resultante deve pareecer um conjunto de tokens semelhante ao mostrado abaixo. O que isso significa é que você pode atualizar qualquer um dos seus valores de token e todos os seus estilos também serão atualizados automaticamente. Alterar a família de fontes de seus títulos agora é uma questão de alterar um único token.
+
+```
+"typography": {
+  "Headings": {
+    "Display 1": {
+      "Bold": {
+        "fontFamily": "$fontFamilies.heading",
+        "fontWeight": "$fontWeights.heading.bold",
+        "lineHeight": "$lineHeights.tight",
+        "fontSize": "$fontSizes.8xl",
+        "letterSpacing": "$letterSpacing.tighter",
+        "paragraphSpacing": "$paragraphSpacing.none"
+      }
+    },
+    "Display 2": {
+      "Bold": {
+        "fontFamily": "$fontFamilies.heading",
+        "fontWeight": "$fontWeights.heading.bold",
+        "lineHeight": "$lineHeights.tight",
+        "fontSize": "$fontSizes.7xl",
+        "letterSpacing": "$letterSpacing.tighter",
+        "paragraphSpacing": "$paragraphSpacing.none"
+      }
+    },
+    "Display 3": {
+      "Bold": {
+        "fontFamily": "$fontFamilies.heading",
+        "fontWeight": "$fontWeights.heading.bold",
+        "lineHeight": "$lineHeights.tight",
+        "fontSize": "$fontSizes.6xl",
+        "letterSpacing": "$letterSpacing.tighter",
+        "paragraphSpacing": "$paragraphSpacing.none"
+      }
+    }
+  }
+}
+```
+
+## Manter os estilos sincronizados
+
+É claro que você quer que seus estilos sejam atualizados sempre que atualizar seus tokens. Para fazer isso, é importante manter a estrutura de nomenclatura dos tokens igual aos seus estilos no Figma. Ou seja, se você renomear quaisquer tokens, certifique-se de renomear suas contrapartes de estilos também.
+
+Se você criar um novo estilo posteriormente e quiser mantê-lo em tokens, crie-o no Figma Tokens e use o botão `Create Styles`, ao invés de aplicar Import Styles novamente.
+
+`Create Styles` basicamente diz ao Figma para criar qualquer estilo que não exista.
+
+![](/create-styles.jpg)

--- a/pages/sync.pt-br.md
+++ b/pages/sync.pt-br.md
@@ -1,0 +1,39 @@
+# Sincronizar (Sync)
+
+Como os tokens fazem mais sentido em um ambiente de equipe, algum tipo de sincronização é necessário para manter os valores atualizados enquanto a equipe está trabalhando em arquivos diferentes.
+
+### JSONBin
+
+Para começar a habilitar o Sync para o seu arquivo, vá para a guia `Sync` no plugin. Escolha `JSONBin` para selecionar JSONBin como seu provedor de sincronização.
+
+Ao iniciar o recurso Sincronizar pela primeira vez, você não terá nenhuma credencial de provedor armazenada em seu dispositivo. Vá em frente e selecione `Add Credentials`.
+
+Para `name`, escolha o nome que desejar. Você pode alterar o nome mais tarde.
+
+Agora você precisa pegar suas credenciais do JSONBin. Para fazer isso, acesse JSONBin.io e registre uma conta.
+
+Uma vez logado, clique no seu avatar e selecione `API-Keys`. Lá você encontrará sua chave secreta (`secret key`). Copie e insira no campo `Secret` no Figma Tokens.
+
+Se você deseja criar um novo bin de sincronização, você pode deixar a parte ID em branco. O plugin irá criar um novo bin para você. Você também pode inserir um ID existente neste campo para vincular um compartimento existente.
+
+import Callout from 'nextra-theme-docs/callout'
+
+<Callout emoji="💡">
+  Ao criar um novo bin, seus tokens são carregados para esse bin. No entanto, ao usar um ID existente, os tokens armazenados no controle remoto sobrescreverão os existentes.
+</Callout>
+
+### Trazendo sua equipe a bordo
+
+Depois de definir um provedor para um documento, armazenamos a ID e o nome do seu compartimento neste documento. O `Secret` é deixado em branco, então cada membro da equipe terá que adicionar o segredo por conta própria. A razão para isso é que, no futuro, queremos habilitar diferentes permissões com base em diferentes usuários, alguns atuando apenas como consumidores, outros como colaboradores.
+
+### Alterar credenciais de armazenamento
+
+Você pode alternar entre as diferentes caixas de tokens armazenadas sempre que desejar. Para fazer isso, após ter criado mais de um item de provedor, clique em `Apply` para aplicar este conjunto de tokens ao documento atual.
+
+### Atualizando tokens
+
+Sempre que você atualizar um token, o remoto será atualizado automaticamente. Atualmente, não há nenhum processo de `Publish` em vigor, exceto a atualização de tokens.
+
+### Pegando mudanças
+
+O plugin irá buscar automaticamente os tokens remotos mais recentes em sua inicialização. De vez em quando, sua equipe pode ter feito alterações enquanto você estava com o plug-in aberto, para obter as alterações mais recentes, clique no botão `Pull from JSONbin` no canto superior direito.

--- a/pages/token-sets.pt-br.md
+++ b/pages/token-sets.pt-br.md
@@ -1,0 +1,41 @@
+# Token Sets (Temas)
+
+Com a Versão 36, conjuntos de token (`Tokens Sets`, ou temas) são introduzidos!
+
+Agora você pode dividir seus tokens em vários conjuntos ou temas.
+
+Dividir tokens tem muitos benefícios:
+- Permitem que você divida opções e decisões
+- Oferece a capacidade de separar semanticamente tokens
+- Conjuntos diferentes podem ser expostos ativando apenas o que você precisa
+
+---
+
+import ReactPlayer from 'react-player'
+
+<ReactPlayer
+  muted
+  width="100%"
+  height="auto"
+  loop
+  playing
+  controls
+  url="/8M7EiMsoIW.mp4"
+/>
+
+##### Criando sets
+Você pode criar um novo conjunto clicando no `+` próximo aos conjuntos existentes. Insira um nome único.
+
+![](/token-sets.png)
+
+#### Mudando para um conjunto (set)
+Clique no conjunto de tokens (não na caixa de seleção) para mudar o contexto do editor para este novo conjunto.
+
+#### Renomeando ou excluindo um conjunto (set)
+Clique com o botão direito em um conjunto para exibir as opções de renomear e excluir.
+
+#### Ativando (verificando) um conjunto (set)
+Ao marcar a caixa de seleção, você ativa este conjunto, o que significa que esses tokens serão expostos ao Figma. Se você tiver vários conjuntos (por exemplo, um tema claro e um tema escuro), poderá substituir as decisões que podem ter sido definidas em outro conjunto.
+
+#### Alteração da ordem dos conjuntos
+Você pode arrastar conjuntos para definir sua ordem. Todos os conjuntos de tokens ativos são expostos e mesclados em um grande conjunto de tokens, se alguns tokens tiverem exatamente o mesmo nome e caminho, o último ganha (por exemplo, se `colors.foreground` existe em um tema claro e escuro, aquele que é visível mais tarde nas vitórias do `set list`)

--- a/pages/tokens/aliases.pt-br.md
+++ b/pages/tokens/aliases.pt-br.md
@@ -1,0 +1,15 @@
+# Apelidos (Aliases)
+
+A coisa legal sobre Figma Tokens é que você pode fazer referência a outros tokens como um valor para seus tokens (ou, como podemos chamar, seus estilos). Isso significa que você pode fazer com que a cor de sua marca seja uma referência a `colors.red.500`, ou ter um token de fundo que obtém seu valor de um token de `colors.black` enquanto um token de primeiro plano obtém seu valor de um token `colors.white`.
+
+Para usar um alias em seus tokens, nós os escrevemos na seguinte notação: `$spacing.sm`
+
+import Callout from 'nextra-theme-docs/callout'
+
+<Callout emoji="💡">
+  As referências (`references`) são sensíveis a maiúsculas e minúsculas, o que significa que você deve escrever suas referências como seus tokens são nomeados (geralmente em minúsculas).
+</Callout>
+
+O que isso faz é dizer ao plugin para procurar um token de `spacing.sm`, se for encontrado, usar esse valor. Sempre que você altera `spacing.sm`, o token que o referencia também muda.
+
+Você também pode incorporar apelidos dentro de tokens de cores! Se você quiser um estilo de cor que use a cor da marca, mas reduza sua opacidade para 50%, basta escrever: `rgba ($colors.brand, 0.5)`

--- a/pages/tokens/applying-tokens.pt-br.md
+++ b/pages/tokens/applying-tokens.pt-br.md
@@ -1,0 +1,9 @@
+# Aplicando tokens
+
+Existem duas maneiras de aplicar tokens à sua seleção:
+
+### Comportamento padrão (botão esquerdo)
+Quando você clica com o botão esquerdo em um token, ele é colocado em sua seleção (várias camadas selecionadas são possíveis!). Para certos tokens, determinamos os padrões - como em `Colors`, onde assumimos que você deseja aplicar `Fill`.
+
+### Especificando o que aplicar (clique com o botão direito)
+Você pode clicar com o botão direito do mouse nos tokens para especificar qual propriedade deve ser definida, como em `Spacing` as propriedades `Horizontal Spacing`, `Vertical Spacing` ou `Gap` individualmente.

--- a/pages/tokens/available-tokens.pt-br.md
+++ b/pages/tokens/available-tokens.pt-br.md
@@ -4,18 +4,18 @@ No plugin Figma Tokens, você pode criar Design Tokens reutilizáveis e semânti
 
 Os grupos de tokens disponíveis até o momento são:
 
-| Grupo                   | Grupo Tradução             | Aplicação                                |
-| :---------------------- | :------------------------- | :--------------------------------------- |
-| Sizing                  | Tamanho                    | Width, height                            |
-| Spacing                 | Espaçamentos               | Auto-Layout                              |
-| Color                   | Cores                      | Fill, border                             |
-| Border radius           | Arredondamento das bordas  | All corners, individual                  |
-| Border width            | Largura das bordas         | Border width                             |
-| Opacity                 | Opacidade                  | Opacity                                  |
-| Font family             | Família de Fontes          | Text layers (in combination with weight) |
-| Font weight             | Peso da Fonte              | Text layers (in combination with family) |
-| Font size               | Tamanho da Fonte           | Text layers                              |
-| Line height             | Altura da Linha            | Text layers                              |
-| Letter spacing          | Espaço dos caracteres      | Text layers                              |
-| Paragraph spacing       | Espaço do parágrafo        | Text layers                              |
-| Typography compositions | Composição de Tipografia   | Text layers, styles                      |
+| Grupo                   | Grupo (Tradução)           | Aplicação                                | Aplicação (Tradução)                     |
+| :---------------------- | :------------------------- | :--------------------------------------- | :--------------------------------------- |
+| Sizing                  | Tamanho                    | Width, height                            | Largura, altura                          |
+| Spacing                 | Espaçamentos               | Auto-Layout                              | Auto-Layout                              |
+| Color                   | Cores                      | Fill, border                             | Preenchimento, borda                     |
+| Border radius           | Arredondamento das bordas  | All corners, individual                  | Todas as bordas, individual              |
+| Border width            | Largura das bordas         | Border width                             | Largura da borda                         |
+| Opacity                 | Opacidade                  | Opacity                                  | Opacidade                                |
+| Font family             | Família de Fontes          | Text layers (in combination with weight) | Camadas de texto (combinado com peso)    |
+| Font weight             | Peso da Fonte              | Text layers (in combination with family) | Camadas de texto (combinado com família) |
+| Font size               | Tamanho da Fonte           | Text layers                              | Camadas de texto                         |
+| Line height             | Altura da Linha            | Text layers                              | Camadas de texto                         |
+| Letter spacing          | Espaço dos caracteres      | Text layers                              | Camadas de texto                         |
+| Paragraph spacing       | Espaço do parágrafo        | Text layers                              | Camadas de texto                         |
+| Typography compositions | Composição de Tipografia   | Text layers, styles                      | Camadas de texto, estilos                |

--- a/pages/tokens/available-tokens.pt-br.md
+++ b/pages/tokens/available-tokens.pt-br.md
@@ -1,0 +1,21 @@
+# Tokens Disponíveis
+
+No plugin Figma Tokens, você pode criar Design Tokens reutilizáveis e semânticos para seus processos de Design.
+
+Os grupos de tokens disponíveis até o momento são:
+
+| Grupo                   | Grupo Tradução             | Aplicação                                |
+| :---------------------- | :------------------------- | :--------------------------------------- |
+| Sizing                  | Tamanho                    | Width, height                            |
+| Spacing                 | Espaçamentos               | Auto-Layout                              |
+| Color                   | Cores                      | Fill, border                             |
+| Border radius           | Arredondamento das bordas  | All corners, individual                  |
+| Border width            | Largura das bordas         | Border width                             |
+| Opacity                 | Opacidade                  | Opacity                                  |
+| Font family             | Família de Fontes          | Text layers (in combination with weight) |
+| Font weight             | Peso da Fonte              | Text layers (in combination with family) |
+| Font size               | Tamanho da Fonte           | Text layers                              |
+| Line height             | Altura da Linha            | Text layers                              |
+| Letter spacing          | Espaço dos caracteres      | Text layers                              |
+| Paragraph spacing       | Espaço do parágrafo        | Text layers                              |
+| Typography compositions | Composição de Tipografia   | Text layers, styles                      |

--- a/pages/tokens/color-tokens.pt-br.md
+++ b/pages/tokens/color-tokens.pt-br.md
@@ -1,0 +1,36 @@
+# Tokens de cor
+
+Os tokens de cor constituem uma grande parte dos tokens do Figma, pois eles estão fortemente integrados aos estilos do Figma, mas oferecem opções que os Estilos (ainda) não oferecem.
+
+Você pode usar tokens de cores para várias coisas:
+
+- Atualizando estilos de cores
+- Criação de estilos de cores
+- Aplicando uma cor de preenchimento
+- Aplicando uma cor de traço
+
+## Cores sólidas
+
+Existem várias maneiras de escrever tokens de cores:
+
+- Hex: `#ff0000`
+- RGB: `rgb(255, 0, 0)`
+- RGBA: `rgba(255, 0, 0, 1)`
+- HSLA: `hsl(120, 50, 50, 1)`
+
+Por padrão, um token faz referência a uma cor sólida (cores únicas).
+
+## Gradientes
+
+Você pode definir tokens de cor gradiente especificando uma sintaxe semelhante a css: `linear-gradient(45deg, #ffffff 0%, #000000 100%)`..
+
+Se você precisar de várias etapas de cores, basta adicionar mais (o mínimo é 2). `linear-gradient(45deg, #ffffff 0%, #ff0000 50%, #000000 100%)`
+
+### Referências de token
+A grande vantagem dos gradientes de token é que você pode criá-los com referência a outro token, algo que não é possível no próprio Figma. `linear-gradient(45deg, $colors.white 0%, $colors.black 100%)`
+
+### Valores alfa (opacidade)
+A opacidade também é suportada, você pode escrever seus gradientes assim: `linear-gradient(45deg, rgba($colors.primary, 0.5) 0%, rgba($colors.primary, 1) 100%)`
+
+### Limitações
+- Posicionar seu gradiente em uma camada, como você pode fazer no Figma, atualmente não é possível, pois não saberemos onde posicioná-lo, pois armazenamos apenas o grau, não qualquer translação.

--- a/pages/tokens/creating-tokens.pt-br.md
+++ b/pages/tokens/creating-tokens.pt-br.md
@@ -1,0 +1,21 @@
+# Criação de tokens
+
+Criar um novo token por meio da UI é um processo simples. Como exemplo, crie um novo token no grupo Fill clicando no ícone `+` no grupo `Fill`.
+
+No modal que aparece, dê um nome ao seu token, por exemplo `blue` com um valor de `#0000FF`, salve seu progresso clicando em `Create`.
+
+### Editando tokens
+Para alterar o valor de um token existente, clique com o botão direito no token que deseja editar e selecione `Edit Token`.
+
+Você também pode alterar o nome do token, o que atualizará automaticamente todas as referências a este token.
+
+### Grupos de token
+Como gerar muitos tokens pode se tornar bastante confuso, você pode agrupar seus tokens adicionando-os a um grupo de tokens. Existem duas maneiras de fazer isso:
+
+#### Crie um novo grupo de tokens
+Vá para a caixa a caixa `Edit Token` da propriedade para a qual deseja criar um grupo e clique no botão `Add a new group`.
+
+#### Crie um novo grupo adicionando um novo token
+Ao adicionar um novo token, você pode simplesmente escrever seus tokens em nomes separados por pontos. Nomear seu novo token `primary.500` irá adicionar este novo token ao grupo `primary` e com um nome de `500`.
+
+Você pode remover grupos de tokens clicando com o botão direito neles e selecionando `Delete`.

--- a/pages/tokens/documentation-tokens.pt-br.md
+++ b/pages/tokens/documentation-tokens.pt-br.md
@@ -1,0 +1,28 @@
+# Tokens de documentação
+
+Para facilitar a criação de uma documentação de tokens, a versão 50 introduziu os *tokens de documentação*. Com os tokens de documentação, você pode criar uma folha de referência que está vinculada aos seus tokens e será atualizada sempre que você atualizar seus tokens, como neste exemplo:
+
+![](/size-example.jpg)
+
+### Como faço para obter minha própria folha de token?
+
+1. Selecione uma camada de texto;
+2. Clique com o botão direito no token que você deseja fazer referência;
+3. Selecione uma das 3 opções de token de documentação: Nome (*Name*), Valor Bruto (*raw value*), descrição (*Description*);
+4. Sempre que você alterar o valor de um token (ou sua descrição), o conteúdo de texto desta camada será atualizado.
+
+![](/size-howto.jpg)
+
+---
+
+import ReactPlayer from 'react-player'
+
+<ReactPlayer
+  muted
+  width="100%"
+  height="auto"
+  loop
+  playing
+  controls
+  url="/documentation-tokens.mp4"
+/>

--- a/pages/tokens/spacing-tokens.pt-br.md
+++ b/pages/tokens/spacing-tokens.pt-br.md
@@ -1,0 +1,25 @@
+# Tokens de Espaçamento (Spacing)
+
+Os tokens de espaçamento permitem definir valores para `Auto Layout` que podem ser reutilizados. Depois de aplicar um token de espaçamento a uma camada, ele será atualizado sempre que você alterar esse token, portanto, qualquer camada que contenha uma referência a `$spacing.container` será atualizada, quando você atualizar esse token específico.
+
+#### Como usar
+
+Para fazer os tokens de espaçamento funcionarem, comece criando tokens na categoria `Spacing`.
+
+Em seguida, selecione ou crie uma camada de `Auto Layout` (não funcionará em nenhum outro tipo de camada).
+
+Depois de selecionado, aplique os tokens de espaçamento clicando com o botão esquerdo (todos os valores usarão este token) ou clique com o botão direito para especificar qual parte do `Auto Layout` você deseja atingir (`gap`,` horizontal` ou `vertical`. Outros virão em breve).
+
+---
+
+import ReactPlayer from 'react-player'
+
+<ReactPlayer
+  muted
+  width="100%"
+  height="auto"
+  loop
+  playing
+  controls
+  url="/uhrCSTbr5Q.mp4"
+/>

--- a/pages/tokens/using-math.pt-br.md
+++ b/pages/tokens/using-math.pt-br.md
@@ -1,0 +1,11 @@
+# Usando matemática
+
+Muitas vezes, pode fazer sentido construir seus tokens com uma escala em mente, como uma escala de tipografia ou uma escala de espaçamento. O que isso significa é que um valor usa outro valore e faz cálculos com ele.
+
+Por exemplo, você pode querer que seu token `spacing.sm` faça referência ao token `spacing.xs`, porém multiplique seu valor por 2. Para fazer isso, você pode escrever o seguinte como o valor do token: `$spacing.xs * 2` (observe o espaço entre o token e o valor).
+
+Você também pode multiplicar por outro token: `$spacing.xs * $spacing.scale`!
+
+Onde `spacing.scale` seria um token cujo valor poderia ser, por exemplo, 2.
+
+Outros casos de uso em que isso é útil podem ser tipografia com tamanhos de fonte referenciando o token anterior e multiplicar isso com uma escala de tipo de, por exemplo, 1,25.


### PR DESCRIPTION
Below are the first pages translated into PT-BR (Brazilian Portuguese, there is a noticeable difference between the "official" Portuguese).

I inserted an observation in Intro about translated terms, because it doesn't make sense to keep only full translations for terms that are used in the original Program and also common to languages like CSS and HTML.

The observation says:

"Note of translation for Brazilian Portuguese: we decided to keep the nomenclatures with the original names of the CSS and Figma properties for the tokens, categories and other items related to development. However, we use the translation in columns of tables or in parentheses right after this ocurrencies. The objective of this is to cover all professionals, from those who use the tool in Portuguese to those who prefer the original language (English) - even those who need the original references for code (Example: there is no CSS in Portuguese). "