### PR TITLE
Note/exception for Font Families + Font Families

### DIFF
--- a/pages/styles.en.mdx
+++ b/pages/styles.en.mdx
@@ -151,6 +151,9 @@ The resulting import of styles should result in a set of tokens similar to the o
 }
 ```
 
+> Note: While Font Family and Font Weight tokens can be applied individually to text nodes, both must be applied simultaneously to cause a visual change in Figma. 
+
+
 ## Keeping styles in sync
 
 Naturally you'd want your styles to update whenever you update your tokens. In order to do this, it's important to keep the naming structure of the tokens the same as your styles in Figma. Meaning, if you rename any tokens, make sure to rename their styles counterparts as well.


### PR DESCRIPTION
There was no information detailing the dependency between Font Family and Font Weight tokens. A blockquote was added at the end of the Typography Tokens section to let users know that both tokens are needed in order to see the tokens' effects in Figma.