### PR TITLE
Fix link to Pro Layout Panel

### DIFF
--- a/pages/shared-data.en.md
+++ b/pages/shared-data.en.md
@@ -22,4 +22,4 @@ We've [built a tool](https://www.npmjs.com/package/@six7/figma-tokens-helpers) t
 Automator is able to read and write to the shared plugin space. You could create all kinds of crazy automations - you could even create whole token sets using Automator. We've even [built an automation that automatically creates Documentation](https://automator.community/automation/create-documentation-for-figma-tokens) for you!
 
 ### Pro Layout Panel
-What would make a really great Auto Layout enhancement even greater? The ability to choose from design tokens as your spacing values. [Pro Layout Panel](http://plp.plasmic.site/) allows you to do that, so you can use the tokens you created in Figma Tokens and apply those (using the last used set combination in Figma Tokens)
+What would make a really great Auto Layout enhancement even greater? The ability to choose from design tokens as your spacing values. [Pro Layout Panel](https://www.mrbiscuit.design) allows you to do that, so you can use the tokens you created in Figma Tokens and apply those (using the last used set combination in Figma Tokens)


### PR DESCRIPTION
It seems, that Pro Layout Panel website have moved. URL http://plp.plasmic.site/ returns 404 page now.

Link https://www.mrbiscuit.design/ is working and seems official (mentioned here https://www.figma.com/community/plugin/1065130523685842895/Pro-Layout-Panel).