### PR TITLE
updates pages/sync/github.en.mdx 

### DIFF
--- a/pages/sync/github.en.mdx
+++ b/pages/sync/github.en.mdx
@@ -81,6 +81,11 @@ If you use multiple token sets you might also want to create different token fil
 
 Don't want to include the global set in the output but use it for resolving aliases? Provide another parameter like this and the transformer will exclude that in the output: `node token-transformer tokens.json output.json global,dark global`
 
+### 8. Using multi-file sync
+
+If you're using the [Pro] instance of the plugin and wish to transform multiple files in a single folder, instead of specifying a single json as input, you can specify the folder as input.
+
+For example, if the tokens were stored in Figma Tokens inside a folder path like `data/core.json`, `data/functional.json`, `data/components.json`, and your goal was to generate a set of tokens from some combination of those inputs, pass the folder name as the input to `token-transformer` and provide additional arguments as specified above, like this: `node token-transformer data files,to,include files,to,ignore`
 
 <Callout emoji="💡">
   Examples
@@ -90,6 +95,6 @@ Don't want to include the global set in the output but use it for resolving alia
   - [1 theme to css variables](https://github.com/six7/figma-tokens-example)
   - [Multiple themes to css variables](https://github.com/six7/figma-tokens-example-multi)
   - [TailwindCSS with dark and light theme](https://github.com/six7/figma-tokens-example-tailwindcss)
-  
+  - [Multifile, multitheme](https://github.com/TheeMattOliver/figma-tokens-multifile-multitheme-example)
   Let me know if you have other examples you want to share with the community!
 </Callout>

--- a/pages/sync/github.en.mdx
+++ b/pages/sync/github.en.mdx
@@ -83,7 +83,7 @@ Don't want to include the global set in the output but use it for resolving alia
 
 ### 8. Using multi-file sync
 
-If you're using the [Pro] instance of the plugin and wish to transform multiple files in a single folder, instead of specifying a single json as input, you can specify the folder as input.
+If you're using the [Pro](https://www.figmatokens.com/#pricing) instance of the plugin and wish to transform multiple files in a single folder, instead of specifying a single json as input, you can specify the folder as input.
 
 For example, if the tokens were stored in Figma Tokens inside a folder path like `data/core.json`, `data/functional.json`, `data/components.json`, and your goal was to generate a set of tokens from some combination of those inputs, pass the folder name as the input to `token-transformer` and provide additional arguments as specified above, like this: `node token-transformer data files,to,include files,to,ignore`
 

--- a/pages/sync/github.en.mdx
+++ b/pages/sync/github.en.mdx
@@ -81,7 +81,7 @@ If you use multiple token sets you might also want to create different token fil
 
 Don't want to include the global set in the output but use it for resolving aliases? Provide another parameter like this and the transformer will exclude that in the output: `node token-transformer tokens.json output.json global,dark global`
 
-### 8. Using multi-file sync
+#### Using multi-file sync
 
 If you're using the [Pro](https://www.figmatokens.com/#pricing) instance of the plugin and wish to transform multiple files in a single folder, instead of specifying a single json as input, you can specify the folder as input.
 


### PR DESCRIPTION
Howdy folks! 👋 

### What 

Updates `github.en.mdx` with multi-file scenario for tokens transformer and adds an example to the callout for English docs

### Why

Seems like there's a bit of confusion for users on the Pro instance over passing multi-file paths of the parent folder as an argument to the `tokens-transformer` CLI.

### Open questions

[I created a minimal example here](https://github.com/TheeMattOliver/figma-tokens-multifile-multitheme-example/blob/main/package.json) and added it to the callout, but it's probably not much different than the existing "multi-theme" example. The only critical difference is that the package `tokens-transformer` scripts demonstrate including and excluding tokensets from a parent folder passed as a single argument.

### If approved, what's left todo?

- [ ] Portuguese translation + any other i18n support needed