### PR TITLE
Fix self-reference in example JSON

### DIFF
--- a/pages/tokens/json-schema.en.mdx
+++ b/pages/tokens/json-schema.en.mdx
@@ -52,7 +52,7 @@ Tokens can contain references to other tokens.
       "type": "color",
     },
     "primary": {
-      "value": "{colors.primary}",
+      "value": "{colors.red}",
       "type": "color",
     }
   }


### PR DESCRIPTION
Hey there! I actually haven't used Figma Tokens yet (exploring it as an option!) but I saw this example code and figured it probably was supposed to reference the sibling color instead 😄 